### PR TITLE
Exit with error on failure to start server

### DIFF
--- a/cmd/serverd/main.go
+++ b/cmd/serverd/main.go
@@ -19,25 +19,25 @@ var (
 func main() {
 	flag.StringVar(&tlscert, "tlscert", "/etc/certs/tls.crt", "Path to the TLS certificate")
 	flag.StringVar(&tlskey, "tlskey", "/etc/certs/tls.key", "Path to the TLS key")
-	flag.StringVar(&port, "port", "8443", "The port to listen")
+	flag.StringVar(&port, "port", "8443", "The port on which to listen")
 	flag.Parse()
 
 	server := http.NewServer(port)
+
 	go func() {
-		if err := server.ListenAndServeTLS(tlscert, tlskey); err != nil {
-			log.Errorf("Failed to listen and serve: %v", err)
+		// listen shutdown signal
+		signalChan := make(chan os.Signal, 1)
+		signal.Notify(signalChan, syscall.SIGINT, syscall.SIGTERM)
+		sig := <-signalChan
+		log.Errorf("Received %s signal; shutting down...", sig)
+		if err := server.Shutdown(context.Background()); err != nil {
+			log.Error(err)
 		}
 	}()
 
-	log.Infof("Server running in port: %s", port)
-
-	// listen shutdown signal
-	signalChan := make(chan os.Signal, 1)
-	signal.Notify(signalChan, syscall.SIGINT, syscall.SIGTERM)
-	<-signalChan
-
-	log.Infof("Shutdown gracefully...")
-	if err := server.Shutdown(context.Background()); err != nil {
-		log.Error(err)
+	log.Infof("Starting server on port: %s", port)
+	if err := server.ListenAndServeTLS(tlscert, tlskey); err != nil {
+		log.Errorf("Failed to listen and serve: %v", err)
+		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Previously, if the server failed to start (e.g., if it was unable to load
the key or certificate), serverd would remain running indefinitely because
it was waiting for a signal.

This commit modifies the code so that if ListenAndServerTLS returns it will
cause serverd to exit.
